### PR TITLE
GCal events_list(): return all events, not just first 250

### DIFF
--- a/lib/API/Google/GCal.pm
+++ b/lib/API/Google/GCal.pm
@@ -161,15 +161,22 @@ sub events_list {
 
    if (!defined $params->{calendarId}) { die "No calendarId provided as parameter"}
    if (!defined $params->{user}) { die "No user  provided as parameter"}
-   
-   my $res = $self->api_query({ 
-      method => 'get', 
-      route => $self->{api_base}.'/calendars/'.$params->{calendarId}.'/events',
-      user => $params->{user}
-    });
 
-   if (defined $res->{items}) { return $res->{items} };
-   if (defined $res->{error}) { return $res };
+   my (@events, $page_token);
+   do {
+      my $res = $self->api_query({
+         method => 'get',
+         route => $self->{api_base}.'/calendars/'.$params->{calendarId}.'/events?maxResults=2500' . (defined $page_token ? "&pageToken=$page_token" : ''),
+         user => $params->{user}
+      });
+
+      return $res->{error} if defined $res->{error};
+
+      push @events, @{$res->{items}} if defined $res->{items};
+      $page_token = $res->{nextPageToken};
+   } while (defined $page_token);
+
+   return \@events;
 };
 
 


### PR DESCRIPTION
The Google Calendar API v3 limits the number of events returned by the "Events: list" endpoint to 250 by default, and API::Google::GCal provides no means of overriding this behaviour. This commit makes two changes to API::Google::GCal's `events_list()` method so that it returns all events in the requested calendar:

* Iterate over all pages of the event result list by using the `nextPageToken` property in each API response as the value of the pageToken parameter in the next API request.
* Set the `maxResults` query parameter to its maximum permitted value under the v3 API (2500), to minimise the number of API requests that must be made to iterate over all of the result pages.